### PR TITLE
Leveleditor: Bugfixes

### DIFF
--- a/src/grind/core/impl/DateiService.java
+++ b/src/grind/core/impl/DateiService.java
@@ -74,8 +74,8 @@ public class DateiService {
                 Richtung richtung = null;
 
                 klassenname = jsonObject.get("classname").getAsString();
-                posX = jsonObject.get("posX").getAsInt();
-                posY = jsonObject.get("posY").getAsInt();
+                posX = (int) ((float) jsonObject.get("posX").getAsInt() * Einstellungen.LAENGE_KACHELN_X / Einstellungen.LAENGE_KACHELN_X_LEVELEDITOR);
+                posY = (int) ((float) jsonObject.get("posY").getAsInt() * Einstellungen.LAENGE_KACHELN_Y / Einstellungen.LAENGE_KACHELN_Y_LEVELEDITOR);
 
                 if (klassenname.equals("class grind.movables.impl.Spielfigur")) {
                     String richtungsString;

--- a/src/grind/core/impl/Leveleditor.java
+++ b/src/grind/core/impl/Leveleditor.java
@@ -18,6 +18,7 @@ import processing.core.PApplet;
 import processing.core.PConstants;
 import processing.core.PImage;
 
+import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -27,8 +28,6 @@ public class Leveleditor extends Spielsteuerung {
     private static int SpielfeldHoehe;
     private final Spielsteuerung spielsteuerung;
 
-    private final int menuBreite = 1;
-    private final int menuHoehe = 8;
     private final int breiteExit;
     private final int breiteSpeichern;
     private final int breiteLaden;
@@ -45,8 +44,8 @@ public class Leveleditor extends Spielsteuerung {
     private DateiService dateiService;
     private ISpielwelt spielwelt;
     private TileMap tileMap;
-    private IKachel[][] menuArrayKacheln;
-    private IMovable[][] menuArrayMovables;
+    private ArrayList<IKachel> menuArrayKacheln;
+    private ArrayList<IMovable> menuArrayMovables;
     private IKachel aktuelleKachel;
     private IMovable aktuellesMovable;
     private final Button exitButton;
@@ -71,8 +70,8 @@ public class Leveleditor extends Spielsteuerung {
     public Leveleditor(){
         Einstellungen.LAENGE_KACHELN_Y = 30;
         Einstellungen.LAENGE_KACHELN_X = 30;
-        this.menuArrayKacheln = new IKachel[menuHoehe][menuBreite];
-        this.menuArrayMovables = new IMovable[13][1];
+        this.menuArrayKacheln = new ArrayList<>();
+        this.menuArrayMovables = new ArrayList<>();
         this.tileMap = new TileMap();
         this.spielwelt = new DummySpielwelt();
         this.spielsteuerung = new Spielsteuerung();
@@ -135,29 +134,29 @@ public class Leveleditor extends Spielsteuerung {
 
 
         //Befüllen des Menuarrays mit den Kachelarten
-        this.menuArrayKacheln[0][0] = new Baum();
-        this.menuArrayKacheln[1][0] = new DummyHindernis();
-        this.menuArrayKacheln[2][0] = new Fels();
-        this.menuArrayKacheln[3][0] = new Holzbrücke();
-        this.menuArrayKacheln[4][0] = new Levelausgang();
-        this.menuArrayKacheln[5][0] = new Wasser();
-        this.menuArrayKacheln[6][0] = new Weg();
-        this.menuArrayKacheln[7][0] = new Wiese();
+        this.menuArrayKacheln.add( new Baum());
+        this.menuArrayKacheln.add( new DummyHindernis());
+        this.menuArrayKacheln.add( new Fels());
+        this.menuArrayKacheln.add( new Holzbrücke());
+        this.menuArrayKacheln.add( new Levelausgang());
+        this.menuArrayKacheln.add( new Wasser());
+        this.menuArrayKacheln.add( new Weg());
+        this.menuArrayKacheln.add( new Wiese());
 
         //Befüllen des Menuarrays mit den Movables
-        this.menuArrayMovables[0][0] = new Spielfigur(0,0, Richtung.N);
-        this.menuArrayMovables[1][0] = new Schwert(40,40,1);
-        this.menuArrayMovables[2][0] = new Mango(0,0);
-        this.menuArrayMovables[3][0] = new Levelende(0,0,40);
-        this.menuArrayMovables[4][0] = new Heiltrank(0,0);
-        this.menuArrayMovables[5][0] = new Gold(0,0);
-        this.menuArrayMovables[6][0] = new Apfel(0,0);
-        this.menuArrayMovables[7][0] = new DornPflanze(0,0,this.tileMap);
-        this.menuArrayMovables[8][0] = new FeuerMonster(0,0,this.tileMap,this.spielsteuerung,Richtung.N,1, FeuerModus.RANDOM);
-        this.menuArrayMovables[9][0] = new Geist(0,0,this.tileMap);
-        this.menuArrayMovables[10][0] = new Zombie(0,0,this.tileMap,Richtung.N,this.spielsteuerung, LaufModus.DEFAULT);
-        this.menuArrayMovables[11][0] = new Bogen(40,40,1);
-        this.menuArrayMovables[12][0] = new Spezialattacke(40,40,1);
+        this.menuArrayMovables.add( new Spielfigur(0,0, Richtung.N));
+        this.menuArrayMovables.add( new Schwert(40,40,1));
+        this.menuArrayMovables.add( new Mango(0,0));
+        this.menuArrayMovables.add( new Levelende(0,0,40));
+        this.menuArrayMovables.add( new Heiltrank(0,0));
+        this.menuArrayMovables.add( new Gold(0,0));
+        this.menuArrayMovables.add( new Apfel(0,0));
+        this.menuArrayMovables.add( new DornPflanze(0,0,this.tileMap));
+        this.menuArrayMovables.add( new FeuerMonster(0,0,this.tileMap,this.spielsteuerung,Richtung.N,1, FeuerModus.RANDOM));
+        this.menuArrayMovables.add( new Geist(0,0,this.tileMap));
+        this.menuArrayMovables.add( new Zombie(0,0,this.tileMap,Richtung.N,this.spielsteuerung, LaufModus.DEFAULT));
+        this.menuArrayMovables.add( new Bogen(40,40,1));
+        this.menuArrayMovables.add( new Spezialattacke(40,40,1));
 
     }
 
@@ -280,14 +279,20 @@ public class Leveleditor extends Spielsteuerung {
     private void zeichne() {
         //this.spielmodell.getTileMap().zeichne(this);
         zeichneTileMap();
-        zeichneMovables();
-        zeichneAssetMenu(this.menuArrayKacheln);
-        zeichneMovableMenu(this.menuArrayMovables);
+        if (spielwelt.getSzene(levelNr-1) instanceof ILevel) {
+            zeichneLevel();
+        }
         zeichneMausKachel(aktuelleKachel, mouseX, mouseY);
         zeichneMausMovable(aktuellesMovable,mouseX,mouseY);
         zeichneButtons();
         zeichneCounts();
         zeichneFehler();
+    }
+
+    private void zeichneLevel() {
+        zeichneMovables();
+        zeichneAssetMenu(this.menuArrayKacheln);
+        zeichneMovableMenu(this.menuArrayMovables);
     }
 
     /**
@@ -306,30 +311,61 @@ public class Leveleditor extends Spielsteuerung {
         int mausYmenu = mouseY / Einstellungen.LAENGE_KACHELN_Y;
         int mausXkachel = mouseX / Einstellungen.LAENGE_KACHELN_X;
         int mausYkachel = mouseY / Einstellungen.LAENGE_KACHELN_Y;
+        int mausYmovable = mausYkachel * Einstellungen.LAENGE_KACHELN_Y + Einstellungen.LAENGE_KACHELN_Y/2;
+        int mausXmovable = mausXkachel * Einstellungen.LAENGE_KACHELN_X + Einstellungen.LAENGE_KACHELN_X/2;
+        int ausenXKoordMovable = SpielfeldBreite + Einstellungen.LAENGE_KACHELN_X;
+        int ausenXKoordKachel = SpielfeldBreite + 2 * Einstellungen.LAENGE_KACHELN_X;
 
         if (mouseButton == LEFT) {
-            if (mouseX > SpielfeldBreite && mouseX <= SpielfeldBreite + menuBreite * Einstellungen.LAENGE_KACHELN_X) {
-                if (mouseY < menuHoehe * Einstellungen.LAENGE_KACHELN_Y) {
+            if (mouseX > SpielfeldBreite && mouseX <= ausenXKoordMovable) {
+                if (mouseY < menuArrayKacheln.size() * Einstellungen.LAENGE_KACHELN_Y) {
                     aktuellesMovable = null;
-                    aktuelleKachel = getMenukacheliKachel(mausYmenu, mausXmenu, this.menuArrayKacheln);
+                    aktuelleKachel = getMenukacheliKachel(mausYmenu, mausXmenu, menuArrayKacheln);
                 }
-            } else if (mouseX > SpielfeldBreite + menuBreite && mouseX <= SpielfeldBreite + (2 * menuBreite) * Einstellungen.LAENGE_KACHELN_X){
-                if (mouseY < 13 * Einstellungen.LAENGE_KACHELN_Y){
+            } else if (mouseX > SpielfeldBreite && mouseX <= ausenXKoordKachel){
+                if (mouseY < menuArrayMovables.size() * Einstellungen.LAENGE_KACHELN_Y){
                     aktuelleKachel = null;
                     aktuellesMovable = getMenukacheliMovable(mausYmenu, mausXmenu - 1, menuArrayMovables);
                 }
             }
-            if (mouseX <= SpielfeldBreite && mouseY <= SpielfeldHoehe && (aktuelleKachel != null || aktuellesMovable != null)) {
+            if (mouseX <= SpielfeldBreite && mouseY <= SpielfeldHoehe) {
                 if (aktuelleKachel != null){
                     tileMap.setKachel(aktuelleKachel, mausYkachel, mausXkachel);
                 } else if (aktuellesMovable != null){
-                    aktuellesMovable.setPosition(mouseX,mouseY);
+                    aktuellesMovable.setPosition(mausXmovable,mausYmovable);
                     addMovablezuLevel(aktuellesMovable);
+                } else if (aktuelleKachel == null && aktuellesMovable == null){
+                    aktuelleKachel = tileMap.getKachel(mausYkachel, mausXkachel);
+                    tileMap.setKachel(new Wiese(), mausYkachel, mausXkachel);
+//                    ILevel templevel = (ILevel) spielwelt.getSzene(levelNr-1);
+//                    List<IMovable> movableList = templevel.getPositionen();
+//                    for (IMovable movable : movableList){
+//                        int posX = movable.getPosX();
+//                        int posY = movable.getPosY();
+//
+//                        if (posX == mausXmovable && posY == mausYmovable){
+//                            aktuellesMovable = movable;
+//                            movableList.remove(movable);
+//                        }
+//                    }
                 }
             }
+//            if (mouseX <= SpielfeldBreite && mouseY <= SpielfeldHoehe && (aktuelleKachel != null || aktuellesMovable != null)) {
+//                if (aktuelleKachel != null){
+//                    tileMap.setKachel(aktuelleKachel, mausYkachel, mausXkachel);
+//                } else if (aktuellesMovable != null){
+//                    aktuellesMovable.setPosition(mausXmovable,mausYmovable);
+//                    addMovablezuLevel(aktuellesMovable);
+//                }
+//            }
             buttonAction(mouseY, mouseX);
 
         } else if (mouseButton == RIGHT){
+            if (aktuelleKachel == null && aktuellesMovable == null){
+                tileMap.setKachel(new Wiese(), mausYkachel, mausXkachel);
+//                    ILevel templevel = (ILevel) spielwelt.getSzene(levelNr-1);
+//                    templevel.getPositionen().
+            }
             aktuelleKachel = null;
             aktuellesMovable = null;
         }
@@ -388,11 +424,11 @@ public class Leveleditor extends Spielsteuerung {
      * Zeichnet das Menü mit den verfügbaren Kacheln am rechten Rand.
      * @param menuArray Das Menuarray mit den verschiedenen Kachelarten
      */
-    private void zeichneAssetMenu(IKachel[][] menuArray){
+    private void zeichneAssetMenu(ArrayList<IKachel> menuArray){
         int mapAussenX = SpielfeldBreite;
         int mapAussenY = 0;
-        for (IKachel[] iKachels : menuArray) {
-            iKachels[0].zeichne(this, mapAussenX, mapAussenY);
+        for (IKachel iKachels : menuArray) {
+            iKachels.zeichne(this, mapAussenX, mapAussenY);
             mapAussenY += Einstellungen.LAENGE_KACHELN_Y;
 
             if (mapAussenY >= SpielfeldHoehe) {
@@ -407,19 +443,19 @@ public class Leveleditor extends Spielsteuerung {
      * Die Spielfigur wird als reines Bild dargestellt, da sonst der Lebensbalken mitgezeichnet werden muss.
      * @param menuArray Das Menuarray mit den verschiedenen Movablearten
      */
-    private void zeichneMovableMenu(IMovable[][] menuArray){
+    private void zeichneMovableMenu(ArrayList<IMovable> menuArray){
         int mapAussenX = SpielfeldBreite + Einstellungen.LAENGE_KACHELN_X + Einstellungen.LAENGE_KACHELN_X/2;
         int mapAussenY = Einstellungen.LAENGE_KACHELN_Y/2;
         this.pushStyle();
         this.imageMode(CENTER);
         this.ellipseMode(CENTER);
         this.rectMode(CENTER);
-        for (IMovable[] iMovables : menuArray) {
-            iMovables[0].setPosition(mapAussenX, mapAussenY);
-            if (iMovables[0] instanceof Spielfigur) {
-                this.image((PImage) getImages().get(iMovables[0].getClass().toString()), mapAussenX, mapAussenY, Einstellungen.GROESSE_SPIELFIGUR, Einstellungen.GROESSE_SPIELFIGUR);
+        for (IMovable iMovables : menuArray) {
+            iMovables.setPosition(mapAussenX, mapAussenY);
+            if (iMovables instanceof Spielfigur) {
+                this.image((PImage) getImages().get(iMovables.getClass().toString()), mapAussenX, mapAussenY, Einstellungen.GROESSE_SPIELFIGUR, Einstellungen.GROESSE_SPIELFIGUR);
             } else {
-                iMovables[0].zeichne(this);
+                iMovables.zeichne(this);
             }
             mapAussenY += Einstellungen.LAENGE_KACHELN_Y;
 
@@ -438,9 +474,9 @@ public class Leveleditor extends Spielsteuerung {
      * @param iKachel Das Array mit den Kacheln
      * @return Kachel an Stelle [x][y]
      */
-    private IKachel getMenukacheliKachel(int mausY, int mausX, IKachel[][] iKachel){
+    private IKachel getMenukacheliKachel(int mausY, int mausX, ArrayList<IKachel> iKachel){
 
-        return iKachel[mausY][mausX];
+        return iKachel.get(mausY);
     }
 
     /**
@@ -450,9 +486,9 @@ public class Leveleditor extends Spielsteuerung {
      * @param iMovable Das Array mit den Movables
      * @return Movable an Stelle [x][y]
      */
-    private IMovable getMenukacheliMovable (int mausY, int mausX, IMovable[][] iMovable){
+    private IMovable getMenukacheliMovable (int mausY, int mausX, ArrayList<IMovable> iMovable){
 
-        return iMovable[mausY][mausX];
+        return iMovable.get(mausY);
     }
 
     /**

--- a/src/grind/util/Einstellungen.java
+++ b/src/grind/util/Einstellungen.java
@@ -6,6 +6,8 @@ public class Einstellungen {
     public static final int ANZAHL_KACHELN_Y = 20;
     //Längen sich nicht mehr final, da sie im Leveleditor
     //verkleinert werden, um alles auf kleineren Bildschirmen darzustellen
+    public static int LAENGE_KACHELN_X_LEVELEDITOR = 30;
+    public static int LAENGE_KACHELN_Y_LEVELEDITOR = 30;
     public static int LAENGE_KACHELN_X = 40;
     public static int LAENGE_KACHELN_Y = 40;
     public static final char TASTE_INVENTAR = 'e';


### PR DESCRIPTION
Sechzehnter Commit für Leveleditor: Bugfix für Movableposition.
Movables können nur noch in Kachelplätzen platziert werden. Dies dient zum erneuten Verschieben und Löschen, falls sie falsch gesetzt wurden. Platzierte Kacheln können ab sofort, wenn Maus nicht mit etwas Anderem belegt ist, erneut verschoben oder gelöscht werden. Menüarrays wurden durch Listen ersetzt, um ein Hinzufügen von neuen Gegenständen zu erleichtern.